### PR TITLE
short_alloc: if allocation still fits exactly into arena, it should be used

### DIFF
--- a/short_alloc.h
+++ b/short_alloc.h
@@ -70,6 +70,8 @@ arena<N, alignment>::allocate(std::size_t n)
         ptr_ += aligned_n;
         return r;
     }
+
+    static_assert(alignment <= alignof(std::max_align_t), "you've chosen an alignment that is larger than alignof(std::max_align_t), and cannot be guaranteed by normal operator new");
     return static_cast<char*>(::operator new(n));
 }
 

--- a/short_alloc.h
+++ b/short_alloc.h
@@ -64,7 +64,7 @@ arena<N, alignment>::allocate(std::size_t n)
     static_assert(ReqAlign <= alignment, "alignment is too small for this arena");
     assert(pointer_in_buffer(ptr_) && "short_alloc has outlived arena");
     auto const aligned_n = align_up(n);
-    if (ptr_ + aligned_n <= buf_ + N)
+    if (static_cast<decltype(aligned_n)>(buf_ + N - ptr_) >= aligned_n)
     {
         char* r = ptr_;
         ptr_ += aligned_n;

--- a/short_alloc.h
+++ b/short_alloc.h
@@ -49,7 +49,7 @@ private:
     static
     std::size_t 
     align_up(std::size_t n) noexcept
-        {return n + (alignment-1) & ~(alignment-1);}
+    {return (n + (alignment-1)) & ~(alignment-1);}
 
     bool
     pointer_in_buffer(char* p) noexcept
@@ -62,9 +62,9 @@ char*
 arena<N, alignment>::allocate(std::size_t n)
 {
     static_assert(ReqAlign <= alignment, "alignment is too small for this arena");
-    assert(pointer_in_buffer(ptr_) && "short_alloc has outlived arena");
+
     auto const aligned_n = align_up(n);
-    if (buf_ + N - ptr_ >= aligned_n)
+    if (ptr_ + n <= buf_ + N)
     {
         char* r = ptr_;
         ptr_ += aligned_n;
@@ -77,8 +77,8 @@ template <std::size_t N, std::size_t alignment>
 void
 arena<N, alignment>::deallocate(char* p, std::size_t n) noexcept
 {
-    assert(pointer_in_buffer(ptr_) && "short_alloc has outlived arena");
-    if (pointer_in_buffer(p))
+
+    if (p + n <= buf_ + N)
     {
         n = align_up(n);
         if (p + n == ptr_)

--- a/short_alloc.h
+++ b/short_alloc.h
@@ -78,7 +78,7 @@ void
 arena<N, alignment>::deallocate(char* p, std::size_t n) noexcept
 {
 
-    if (p + n <= buf_ + N)
+    if ((buf_ <= p) && (p + n <= buf_ + N))
     {
         n = align_up(n);
         if (p + n == ptr_)


### PR DESCRIPTION
Thanks for `short_alloc`! (I've been experimenting with using it with containers without using the freestore, which is nicely efficient (and a requirement in some safety-critical software, or so I'm told)).

I noticed this:
Overlarge alignments can cause the allocation to still fits exactly,
yet cause the arena's `ptr_` to jump out of the arena.
But the allocation is then still valid, even though `ptr_` ends up outside
the arena, since the new position of `ptr_` is only for the _next_ allocation!

Here's a code example. 
It shows non-zero memory, when using the existing version, 
but zero-memory-usage (as desired) when using the code from the pull-request.

``` cpp
#include "short_alloc.h"
#include <iostream>
#include <new>
#include <vector>

// Replace new and delete just for the purpose of demonstrating that
//  they are not called.

std::size_t memory = 0;
std::size_t alloc = 0;

void* operator new(std::size_t s) //throw(std::bad_alloc)
{
  memory += s;
  ++alloc;
  return std::malloc(s);
}

void  operator delete(void* p) noexcept//throw()
{
  --alloc;
  std::free(p);
}

void operator delete(void* ptr, std::size_t) noexcept //throw()
{
    ::operator delete(ptr);
}

void memuse()
{
    std::cout << "memory = " << memory << '\n';
    std::cout << "alloc = " << alloc << '\n';
}

template <class T, std::size_t BufSize = 3*sizeof(T), std::size_t Alig = alignof(T)>
using SmallVector = std::vector<T, short_alloc<T, BufSize, Alig>>;

template <class T, std::size_t BufSize = 3*sizeof(T), std::size_t Alig = 2*alignof(T)> // increase alignment requirement
using SmallVectorXXX = std::vector<T, short_alloc<T, BufSize, Alig>>;

int main()
{
    {
        SmallVector<int>::allocator_type::arena_type a;
        SmallVector<int> v{{1, 2, 3}, a}; // exactly one allocation is made, for exactly 3 ints == 12 bytes
    }
    memuse();

    {
        SmallVectorXXX<int>::allocator_type::arena_type a;
        SmallVectorXXX<int> v{{1, 2, 3}, a}; // exactly one allocation is made, for exactly 3 ints == 12 bytes
        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
        // we jump arena's ptr_ forward a bit more (out of the arena) because of the large alignment
    }
    memuse();
}
```
